### PR TITLE
Update APRS Symbol to official LoRa iGate symbol

### DIFF
--- a/GateWay_Source/Lora_APRS_gateway_6.py
+++ b/GateWay_Source/Lora_APRS_gateway_6.py
@@ -171,7 +171,7 @@ def auth_packet():
     return "user %s pass %s vers %s filter %s\r\n" % (APRS_IS_CALL, APRS_IS_PASSCODE, Version, FILTER)
 
 def position_packet():
-    return ("%s>APOTW1,TCPIP*:!%sI%s&%s/%s\r\n" % (APRS_IS_CALL, LATITUDE, LONGITUDE, PHG, INFO+" "+TempHumPress))
+    return ("%s>APOTW1,TCPIP*:!%sL%s&%s/%s\r\n" % (APRS_IS_CALL, LATITUDE, LONGITUDE, PHG, INFO+" "+TempHumPress))
 
 def send_packet(packet):
     global udp_sock, aprs_is_sock


### PR DESCRIPTION
According to http://www.aprs.org/symbols/symbols-new.txt the new official symbol is L& since 17 March 2021.