### PR TITLE
Fix 4 bugs in transmit igate processing

### DIFF
--- a/APRS.conf
+++ b/APRS.conf
@@ -33,8 +33,9 @@ ShowErrorAtStart:False
 
 #Server-side Filter Commands
 #see http://www.aprs-is.net/javAPRSFilter.aspx
-# Gateway filter
-Filter:t/poimqstunw
+# Gateway filter - an empty filter is good for a gateway, the APRS-IS server
+# will send the correct packets by default.
+Filter:
 
 # Configure this part with your location, PHG (antenna description), and brief info
 #LATITUDE:4802.38N

--- a/Lora_APRS_gateway_6.py
+++ b/Lora_APRS_gateway_6.py
@@ -202,6 +202,21 @@ def handle_aprs_message(reply):
 
         messageSEND=Call+'>LORA::'+To+':'+Text
 
+        # If message is addressed to this gateway, reject it
+        if To.strip().upper()==APRS_IS_CALL.upper():
+            print 'Message addressed to me, rejecting'
+            temp3=reply.rfind('{')
+            if temp3>0:
+                MesNo=reply[temp3+1:]
+                print 'message # ' + MesNo
+                CallPad=APRS_IS_CALL.upper()
+                while(len(CallPad)<9):
+                    CallPad+=' '
+                resp=APRS_IS_CALL.upper()+'>APRS::'+Call.upper()+':rej'+MesNo
+                print 'send to APRS Server ',resp
+                send_packet(replace_path(resp))
+            return
+
         temp3=reply.rfind('{')
         MesNo=''
         if temp3>0:
@@ -214,30 +229,13 @@ def handle_aprs_message(reply):
             message=message+'|A|'+MesNo
             ack_message = '1'+message
             messageSEND='1'+messageSEND
-            if (TRANSMIT=="True"):
-                #udp_sock.sendto(ack_message+'\x00\r', addr)
-                udp_sock.sendto(messageSEND+'\x00\r', addr)
-                print 'send to c++ ',ack_message
-                print 'messageSEND =', messageSEND
-            elif (TRANSMIT=="False"):
-                print 'GW is not alowed to transmit !'
-                #sending reject to APRS Server
-                #IoT4Pi3>APRS::OE1KEB   :rej1
-                while(len(Call)<9):
-                    Call+=' '
-                resp=To.strip().upper()+'>APRS::'+Call.upper()+':rej'+MesNo
-                print 'send to APRS Server ',resp
-                send_packet(replace_path(resp))
 
-        else:
-            if (TRANSMIT=="True"):
-                #udp_sock.sendto(message+'\x00\r', addr)
-                udp_sock.sendto(messageSEND+'\x00\r', addr)
-                print 'send to c++ ',message
-                print 'messageSEND =', messageSEND
-
-            elif (TRANSMIT=="False"):
-                print 'GW is not alowed to send !'
+        if (TRANSMIT=="True"):
+            udp_sock.sendto(messageSEND+'\x00\r', addr)
+            print 'send to c++ ',message
+            print 'messageSEND =', messageSEND
+        elif (TRANSMIT=="False"):
+            print 'GW is not alowed to transmit !'
 
 def process_packets():
     global udp_sock, aprs_is_sock,numPackets,LTime,addr

--- a/Lora_APRS_gateway_6.py
+++ b/Lora_APRS_gateway_6.py
@@ -169,7 +169,7 @@ def auth_packet():
     global APRS_IS_PASSCODE
     global FILTER
     
-    return "user %s pass %s vers %s filter %s\r\n" % (APRS_IS_CALL, APRS_IS_PASSCODE, Version, FILTER)
+    return "user %s pass %s vers iot4pi-LoraAPRSGW 0.3 filter %s\r\n" % (APRS_IS_CALL, APRS_IS_PASSCODE, FILTER)
 
 def position_packet():
     return ("%s>APOTW1,TCPIP*:!%sI%s&%s/%s\r\n" % (APRS_IS_CALL, LATITUDE, LONGITUDE, PHG, INFO+" "+TempHumPress))

--- a/Lora_APRS_gateway_6.py
+++ b/Lora_APRS_gateway_6.py
@@ -180,6 +180,22 @@ def send_packet(packet):
     message = ("%s\r\n" % (packet))
     aprs_is_sock.sendall(message)
 
+def third_party_format(reply):
+    """Format packet to third party format in the TX igate. This is very important,
+    it prevents other igates from (1) forwarding the same packet back from RF
+    to APRS-IS, and (2) assuming that the original sender of the packet is reachable
+    via RF - this would trigger other TX igates to forward messages destined to
+    this station to RF as well. These would cause RF - APRS-IS - RF loops.
+    """
+    
+    # Parse FROMCALL>TOCALL and data from APRS-IS packet
+    # Input format: FROMCALL>TOCALL,path,path:data
+    # Output format: APRS_IS_CALL>APRS:}FROMCALL>TOCALL,TCPIP,APRS_IS_CALL*:data
+    header, data = reply.split(':', 1)
+    fromcall = header.split('>')[0]
+    tocall = header.split('>')[1].split(',')[0]
+    return APRS_IS_CALL+'>LORA:}'+fromcall+'>'+tocall+',TCPIP,'+APRS_IS_CALL+'*:'+data
+
 def handle_aprs_message(reply):
     global addr
     print 'Message Type received :\n'
@@ -200,7 +216,7 @@ def handle_aprs_message(reply):
 
         message='M|'+Call+'|'+Via +'|'+To+'|'+Text
 
-        messageSEND=Call+'>LORA::'+To+':'+Text
+        messageSEND=third_party_format(reply)
 
         # If message is addressed to this gateway, reject it
         if To.strip().upper()==APRS_IS_CALL.upper():

--- a/Lora_APRS_gateway_6.py
+++ b/Lora_APRS_gateway_6.py
@@ -172,7 +172,7 @@ def auth_packet():
     return "user %s pass %s vers iot4pi-LoraAPRSGW 0.3 filter %s\r\n" % (APRS_IS_CALL, APRS_IS_PASSCODE, FILTER)
 
 def position_packet():
-    return ("%s>APOTW1,TCPIP*:!%sI%s&%s/%s\r\n" % (APRS_IS_CALL, LATITUDE, LONGITUDE, PHG, INFO+" "+TempHumPress))
+    return ("%s>APZ4PI,TCPIP*:!%sI%s&%s/%s\r\n" % (APRS_IS_CALL, LATITUDE, LONGITUDE, PHG, INFO+" "+TempHumPress))
 
 def send_packet(packet):
     global udp_sock, aprs_is_sock

--- a/Lora_APRS_gateway_6.py
+++ b/Lora_APRS_gateway_6.py
@@ -49,6 +49,7 @@ REPLACE_PATH=False		# If true, add ",qAR,APRS_IS_CALL" to path
 VERSION=""
 udp_sock = None
 aprs_is_sock = None
+aprs_is_buf = ""
 
 #counter of received packets
 numPackets=0
@@ -266,20 +267,22 @@ def process_packets():
 
 	    elif sock == aprs_is_sock:
                 #Meassages from APRS Server
-                reply = aprs_is_sock.recv(4096)
-                #ReceivedStr=aprs_is_sock.recv(1024)
-                if not reply.startswith('#'):
-#	            print "<-"+ reply.strip()
-#                else:
-                    #######################################
-                    ## Rework with regular expresions !!!!!!!
-                    #######################################
-                    #Proof for Message Type  :123456789:
-                    if reply.rfind(':') and reply[reply.rfind(':')-10:reply.rfind(':')-9]==':':
-                        handle_aprs_message(reply)
+                global aprs_is_buf
+                data = aprs_is_sock.recv(4096)
+                if not data:
+                    continue
+                aprs_is_buf += data
+                while "\r\n" in aprs_is_buf:
+                    reply, aprs_is_buf = aprs_is_buf.split("\r\n", 1)
+                    if not reply.startswith('#'):
+                        #######################################
+                        ## Rework with regular expresions !!!!!!!
+                        #######################################
+                        #Proof for Message Type  :123456789:
+                        if reply.rfind(':') and reply[reply.rfind(':')-10:reply.rfind(':')-9]==':':
+                            handle_aprs_message(reply)
 
-                LTime=time.time()
-                #print  reply
+                    LTime=time.time()
 
 
 def replace_path(packet):

--- a/Lora_APRS_gateway_6.py
+++ b/Lora_APRS_gateway_6.py
@@ -179,8 +179,67 @@ def send_packet(packet):
     message = ("%s\r\n" % (packet))
     aprs_is_sock.sendall(message)
 
+def handle_aprs_message(reply):
+    global addr
+    print 'Message Type received :\n'
+
+    print reply
+    temp1=reply.find('>')
+    Call=reply[0:temp1]
+    print 'Call ' + Call
+    temp2=reply.find('::')
+    if temp2:
+        Via = reply[reply.rfind(',')+1:reply.find('::')]
+        print 'message from ' + Via
+        To=reply[temp2+2:temp2+2+9]
+        print 'message to ' + To
+        Text=reply[temp2+2+9+1:]
+        Text=Text.rstrip()
+        print 'message : ' + Text
+
+        message='M|'+Call+'|'+Via +'|'+To+'|'+Text
+
+        messageSEND=Call+'>LORA::'+To+':'+Text
+
+        temp3=reply.rfind('{')
+        MesNo=''
+        if temp3>0:
+            print 'ACK requested !'
+
+            MesNo=reply[temp3+1:]
+            print 'message # ' + MesNo
+            temp3=message.rfind('{')
+            message=message[:temp3]
+            message=message+'|A|'+MesNo
+            ack_message = '1'+message
+            messageSEND='1'+messageSEND
+            if (TRANSMIT=="True"):
+                #udp_sock.sendto(ack_message+'\x00\r', addr)
+                udp_sock.sendto(messageSEND+'\x00\r', addr)
+                print 'send to c++ ',ack_message
+                print 'messageSEND =', messageSEND
+            elif (TRANSMIT=="False"):
+                print 'GW is not alowed to transmit !'
+                #sending reject to APRS Server
+                #IoT4Pi3>APRS::OE1KEB   :rej1
+                while(len(Call)<9):
+                    Call+=' '
+                resp=To.strip().upper()+'>APRS::'+Call.upper()+':rej'+MesNo
+                print 'send to APRS Server ',resp
+                send_packet(replace_path(resp))
+
+        else:
+            if (TRANSMIT=="True"):
+                #udp_sock.sendto(message+'\x00\r', addr)
+                udp_sock.sendto(messageSEND+'\x00\r', addr)
+                print 'send to c++ ',message
+                print 'messageSEND =', messageSEND
+
+            elif (TRANSMIT=="False"):
+                print 'GW is not alowed to send !'
+
 def process_packets():
-    global udp_sock, aprs_is_sock,numPackets,LTime,addr 
+    global udp_sock, aprs_is_sock,numPackets,LTime,addr
     global TempHumPress
     # Await a read event for 5 seconds
     rlist, wlist, elist = select.select([udp_sock, aprs_is_sock], [], [], 5)
@@ -212,69 +271,13 @@ def process_packets():
                 if not reply.startswith('#'):
 #	            print "<-"+ reply.strip()
 #                else:
-                    temp1=reply.find('>')
                     #######################################
                     ## Rework with regular expresions !!!!!!!
                     #######################################
                     #Proof for Message Type  :123456789:
-                    #if temp1:
                     if reply.rfind(':') and reply[reply.rfind(':')-10:reply.rfind(':')-9]==':':
-                        print 'Message Type received :\n'
-                        
-                        print reply
-                        Call=reply[0:temp1]
-                        print 'Call ' + Call
-                        temp2=reply.find('::')
-                        if temp2:
-                            Via = reply[reply.rfind(',')+1:reply.find('::')]
-                            print 'message from ' + Via
-                            To=reply[temp2+2:temp2+2+9]
-                            print 'message to ' + To
-                            Text=reply[temp2+2+9+1:]
-                            Text=Text.rstrip()
-                            print 'message : ' + Text
+                        handle_aprs_message(reply)
 
-                            message='M|'+Call+'|'+Via +'|'+To+'|'+Text
-                            
-                            messageSEND=Call+'>LORA::'+To+':'+Text
-                            
-                            temp3=reply.rfind('{')
-                            MesNo=''
-                            if temp3>0:
-                                print 'ACK requested !'
-                                
-                                MesNo=reply[temp3+1:]
-                                print 'message # ' + MesNo
-                                temp3=message.rfind('{')
-                                message=message[:temp3]
-                                message=message+'|A|'+MesNo
-                                ack_message = '1'+message
-                                messageSEND='1'+messageSEND
-                                if (TRANSMIT=="True"):
-                                    #udp_sock.sendto(ack_message+'\x00\r', addr)
-                                    udp_sock.sendto(messageSEND+'\x00\r', addr)
-                                    print 'send to c++ ',ack_message
-                                    print 'messageSEND =', messageSEND
-                                elif (TRANSMIT=="False"):
-                                    print 'GW is not alowed to transmit !'
-                                    #sending reject to APRS Server
-                                    #IoT4Pi3>APRS::OE1KEB   :rej1
-                                    while(len(Call)<9):
-                                        Call+=' '
-                                    resp=To.strip().upper()+'>APRS::'+Call.upper()+':rej'+MesNo
-                                    print 'send to APRS Server ',resp
-                                    send_packet(replace_path(resp))
-
-                            else:
-                                if (TRANSMIT=="True"):
-                                    #udp_sock.sendto(message+'\x00\r', addr)
-                                    udp_sock.sendto(messageSEND+'\x00\r', addr)
-                                    print 'send to c++ ',message
-                                    print 'messageSEND =', messageSEND
-                                    
-                                elif (TRANSMIT=="False"):
-                                    print 'GW is not alowed to send !'
-                            
                 LTime=time.time()
                 #print  reply
 


### PR DESCRIPTION
This should fix issues #5 #6 #7 and #8 along with a couple of other issues. Please test on a real device - I don't have an iot4pi device available, but this works for me locally.

Note that the default filter in the example config file (t/poimqstunw) was pretty bad ("send all packets on the APRS-IS of all of these types), the igate doesn't need all those packets. With the old code, due to bug #8 the filter was being ignored by the APRS-IS server. Now when that's fixed, the correct filter setting is more important. An empty filter is good for an igate by default.